### PR TITLE
Updates to .NET Framework 4.6 and Cake 0.22.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ nupkg/
 .nugetapikey
 xtc-api-key
 xtc-email
+.vs/

--- a/Cake.Xamarin.Tests/Cake.Xamarin.Tests.csproj
+++ b/Cake.Xamarin.Tests/Cake.Xamarin.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -28,19 +28,28 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Cake.Common, Version=0.26.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Common.0.26.0\lib\net46\Cake.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="Cake.Core, Version=0.26.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.26.0\lib\net46\Cake.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Cake.Testing, Version=0.26.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Testing.0.26.0\lib\net46\Cake.Testing.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="Cake.Core">
-      <HintPath>..\packages\Cake.Core.0.22.2\lib\net46\Cake.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Cake.Common">
-      <HintPath>..\packages\Cake.Common.0.22.2\lib\net46\Cake.Common.dll</HintPath>
-    </Reference>
-    <Reference Include="Cake.Testing">
-      <HintPath>..\packages\Cake.Testing.0.22.2\lib\net46\Cake.Testing.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Data" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Runtime.Serialization.Json" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Fakes\FakeLog.cs" />
@@ -62,7 +71,8 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
-    <Folder Include="Fakes\" />
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
 </Project>

--- a/Cake.Xamarin.Tests/Cake.Xamarin.Tests.csproj
+++ b/Cake.Xamarin.Tests/Cake.Xamarin.Tests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Cake.Xamarin.Tests</RootNamespace>
     <AssemblyName>Cake.Xamarin.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,13 +33,13 @@
       <HintPath>..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Cake.Core">
-      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Cake.Testing">
-      <HintPath>..\packages\Cake.Testing.0.17.1\lib\net45\Cake.Testing.dll</HintPath>
+      <HintPath>..\packages\Cake.Core.0.22.2\lib\net46\Cake.Core.dll</HintPath>
     </Reference>
     <Reference Include="Cake.Common">
-      <HintPath>..\packages\Cake.Common.0.17.0\lib\net45\Cake.Common.dll</HintPath>
+      <HintPath>..\packages\Cake.Common.0.22.2\lib\net46\Cake.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="Cake.Testing">
+      <HintPath>..\packages\Cake.Testing.0.22.2\lib\net46\Cake.Testing.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Cake.Xamarin.Tests/packages.config
+++ b/Cake.Xamarin.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Common" version="0.17.0" targetFramework="net45" />
-  <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
-  <package id="Cake.Testing" version="0.17.1" targetFramework="net45" />
+  <package id="Cake.Common" version="0.22.2" targetFramework="net46" />
+  <package id="Cake.Core" version="0.22.2" targetFramework="net46" />
+  <package id="Cake.Testing" version="0.22.2" targetFramework="net46" />
   <package id="NUnit" version="3.6.0" targetFramework="net45" />
 </packages>

--- a/Cake.Xamarin.Tests/packages.config
+++ b/Cake.Xamarin.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Common" version="0.22.2" targetFramework="net46" />
-  <package id="Cake.Core" version="0.22.2" targetFramework="net46" />
-  <package id="Cake.Testing" version="0.22.2" targetFramework="net46" />
+  <package id="Cake.Common" version="0.26.0" targetFramework="net46" />
+  <package id="Cake.Core" version="0.26.0" targetFramework="net46" />
+  <package id="Cake.Testing" version="0.26.0" targetFramework="net46" />
   <package id="NUnit" version="3.6.0" targetFramework="net45" />
 </packages>

--- a/Cake.Xamarin/Cake.Xamarin.csproj
+++ b/Cake.Xamarin/Cake.Xamarin.csproj
@@ -29,13 +29,22 @@
     <DocumentationFile>bin\Release\Cake.Xamarin.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Cake.Common, Version=0.26.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Common.0.26.0\lib\net46\Cake.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="Cake.Core, Version=0.26.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.26.0\lib\net46\Cake.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
-    <Reference Include="Cake.Core">
-      <HintPath>..\packages\Cake.Core.0.22.2\lib\net46\Cake.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Cake.Common">
-      <HintPath>..\packages\Cake.Common.0.22.2\lib\net46\Cake.Common.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Data" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Runtime.Serialization.Json" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MDToolSetupRunner.cs" />

--- a/Cake.Xamarin/Cake.Xamarin.csproj
+++ b/Cake.Xamarin/Cake.Xamarin.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Cake.Xamarin</RootNamespace>
     <AssemblyName>Cake.Xamarin</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -31,10 +31,10 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="Cake.Core">
-      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
+      <HintPath>..\packages\Cake.Core.0.22.2\lib\net46\Cake.Core.dll</HintPath>
     </Reference>
     <Reference Include="Cake.Common">
-      <HintPath>..\packages\Cake.Common.0.17.0\lib\net45\Cake.Common.dll</HintPath>
+      <HintPath>..\packages\Cake.Common.0.22.2\lib\net46\Cake.Common.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -48,8 +48,8 @@
     <Compile Include="Aliases.cs" />
     <Compile Include="Namespaces.cs" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Cake.Xamarin/Properties/AssemblyInfo.cs
+++ b/Cake.Xamarin/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("1.0.0")]
+[assembly: AssemblyVersion ("2.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.

--- a/Cake.Xamarin/Properties/AssemblyInfo.cs
+++ b/Cake.Xamarin/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("2.0.0")]
+[assembly: AssemblyVersion ("2.1.0")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.

--- a/Cake.Xamarin/packages.config
+++ b/Cake.Xamarin/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Common" version="0.17.0" targetFramework="net45" />
-  <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
+  <package id="Cake.Common" version="0.22.2" targetFramework="net46" />
+  <package id="Cake.Core" version="0.22.2" targetFramework="net46" />
 </packages>

--- a/Cake.Xamarin/packages.config
+++ b/Cake.Xamarin/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Common" version="0.22.2" targetFramework="net46" />
-  <package id="Cake.Core" version="0.22.2" targetFramework="net46" />
+  <package id="Cake.Common" version="0.26.0" targetFramework="net46" />
+  <package id="Cake.Core" version="0.26.0" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Cake builds using this add in are broken. This change fixes the problem by updating to Cake 0.22.2